### PR TITLE
Fix a few bugs and convert to Python 3

### DIFF
--- a/sndgmail.py
+++ b/sndgmail.py
@@ -54,12 +54,8 @@ if __name__ == "__main__":
  fromaddr = sys.argv[2]
  password = sys.argv[3]
  subject = sys.argv[4]
- body=''
- if len(sys.argv) >= 5:
-  body = sys.argv[4]
- attach_full_path=''
- if len(sys.argv) >= 6:
-  attach_full_path = sys.argv[5]
+ body = sys.argv[5] if len(sys.argv) >= 6 else ''
+ attach_full_path = sys.argv[6] if len(sys.argv) >= 7 else ''
 
  send_email(toaddr,         \
             fromaddr,       \

--- a/sndgmail.py
+++ b/sndgmail.py
@@ -2,10 +2,9 @@ import sys
 import os.path
 import smtplib
 
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEText import MIMEText
-from email.MIMEBase import MIMEBase
-from email import encoders
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.mime.application import MIMEApplication
 
 #--------------------------------------------------------------------------
 # send_mail: Enva un email usando SMTP, usando los siguientes paetros:
@@ -22,7 +21,7 @@ def send_email(toaddr,
                password,
                subject,
                body='',
-               attachfp='',
+               attachfp=None,
                ):
   try:
      msg = MIMEMultipart()
@@ -30,13 +29,12 @@ def send_email(toaddr,
      msg['To'] = toaddr
      msg['Subject'] = subject
      msg.attach(MIMEText(body, 'plain'))
-     if attachfp <> '':
-       part = MIMEBase('application', "octet-stream")
-       part.set_payload( open(file,"rb").read() )
-       Encoders.encode_base64(part)
-       part.add_header('Content-Disposition', 'attachment; filename="%s"'
+     if attachfp:
+       with open(attachfp, "rb") as fp:
+         part = MIMEApplication(fp.read())
+         part.add_header('Content-Disposition', 'attachment; filename="%s"'
                        % os.path.basename(attachfp))
-       msg.attach(part)
+         msg.attach(part)
 
      server = smtplib.SMTP('smtp.gmail.com', 587)
      server.starttls()
@@ -44,8 +42,8 @@ def send_email(toaddr,
      text = msg.as_string()
      server.sendmail(fromaddr, toaddr, text)
      server.quit()
-  except:   
-     pass 
+  except:
+     pass
 #--------------------------------------------------------------------------
 # Punto de Entrada del Programa
 #--------------------------------------------------------------------------

--- a/sndgmail.py
+++ b/sndgmail.py
@@ -1,10 +1,5 @@
 import sys
-import os
 import os.path
-import datetime
-import tempfile
-import re
-import shutil
 import smtplib
 
 from email.MIMEMultipart import MIMEMultipart

--- a/sndgmail.rpgle
+++ b/sndgmail.rpgle
@@ -42,7 +42,7 @@ dcl-proc Main;
                    '"'+%Trim(Attach               )+'" '+
                            
     command = 'STRQSH CMD('''+
-                            'python '                   +
+                            'python3 '                  +
                             %trim(py_script_full_path)  +
                             ' '                         +
                             params_string               +


### PR DESCRIPTION
This syntax is deprecated and not supported in Python 3:
```python
if attachfp <> ''
```
Instead of comparing to empty string, more Pythonic to use the variable in a boolean context.

The argument indexes were also off by one, so body overwrote the subject and the body was interpreted as the file name to attach.

Additionally, Python 2 will go EOL on 2020-01-01, so best to use Python 3, which also makes it easier to attach files. When I tried with Python 2 after fixing the bugs, the existing attach code wasn't working:

```
Traceback (most recent call last):
  File "sndgmail.py", line 65, in <module>
    attach_full_path)
  File "sndgmail.py", line 35, in send_email
    part.set_payload( open(file,"rb").read() )
TypeError: coercing to Unicode: need string or buffer, type found
```